### PR TITLE
lib: allow version to be declared as a var

### DIFF
--- a/lib/lib.go
+++ b/lib/lib.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 )
 
-const VERSION = "2.1"
+var VERSION = "2.1"
 
 type VersionType string
 


### PR DESCRIPTION
If you want to change it at compile time, you need a var, not a const.