### PR TITLE
github: add daily Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Add a Dependabot configuration for the repository's two active\necosystems: GitHub Actions and the root Go module.\n\nBoth update schedules are set to daily so dependency and workflow\nupdates are proposed promptly.

